### PR TITLE
feat/intermediate 056

### DIFF
--- a/intermediate/056/README.md
+++ b/intermediate/056/README.md
@@ -1,0 +1,21 @@
+# [5/23/2012] Challenge #56 [intermediate]
+
+## Source
+
+[Original post](https://old.reddit.com/r/dailyprogrammer/comments/u0tdu/5232012_challenge_56_intermediate/)
+
+## Prompt
+
+At some point or another, most programmers will encounter problems in text processing that has a very elegant solution using [regular expressions](http://en.wikipedia.org/wiki/Regex). But regular expressions can also be over-relied on and abused, and make code unreadable. There is a lot of truth in the old saying "Some people, when confronted with a problem, think 'I know, I'll use regular expressions.' Now they have two problems." So today, lets embrace those two problems and pound some regular expressions into submission!
+
+Your task is to write a regular expression that will match a string if and only if the number of vowels (both upper and lower case) in that string is exactly divisible by 3. For instance, the regular expression will not match the string "Hello!", because there are only two vowels there, "e" and "o" (and 2 is not divisible by 3), but it will match "Daily programmer" because there are six vowels, "D**ai**l**y** pr**o**gr**a**mm**e**r" (and 6 is divisible by 3).
+
+For the purposes of this problem, the vowels of the English language are "A", "E", "I", "O", "U" and "Y" (in both upper and lower cases, obviously).
+
+Here are a few strings you can test your regular expressions on:
+
+1. "Friends, Romans, countrymen, lend me your ears!"
+2. "Double, double, toil and trouble; Fire burn and cauldron bubble."
+3. "Alas, poor Yorick! I knew him, Horatio. A fellow of infinite jest, of most excellent fancy."
+4. "To be, or not to be- that is the question: Whether 'tis nobler in the mind to suffer The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them."
+5. "Everybody stand back! I know regular expressions."

--- a/intermediate/056/rust/Cargo.toml
+++ b/intermediate/056/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
+regex = "1.8.1"
 #itertools = "0.10.3"
 #lazy_static = "1.4.0"
 #rand = "0.8.4"

--- a/intermediate/056/rust/Cargo.toml
+++ b/intermediate/056/rust/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "intermediate_056"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+#itertools = "0.10.3"
+#lazy_static = "1.4.0"
+#rand = "0.8.4"
+#rand_pcg = "0.3.1"
+#regex = "1"

--- a/intermediate/056/rust/Makefile
+++ b/intermediate/056/rust/Makefile
@@ -1,0 +1,6 @@
+# Aliases for executables
+GIT ?= git
+
+INCLUDE_PATH = $(shell git rev-parse --show-toplevel)/rust.mk
+
+include $(INCLUDE_PATH)

--- a/intermediate/056/rust/src/main.rs
+++ b/intermediate/056/rust/src/main.rs
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use regex::Regex;
+
 #[cfg(not(tarpaulin_include))]
 fn main() {
     println!("rad");
 }
 
 fn has_vowels_zero_mod_three(input: &str) -> bool {
-    todo!()
+    let vowels = Regex::new(r"[aeiouy]").unwrap();
+    vowels.find_iter(input).count() % 3 == 0
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/intermediate/056/rust/src/main.rs
+++ b/intermediate/056/rust/src/main.rs
@@ -1,0 +1,29 @@
+// Copyright 2023 CJ Harries
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(not(tarpaulin_include))]
+fn main() {
+    println!("rad");
+}
+
+#[cfg(not(tarpaulin_include))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stub() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/intermediate/056/rust/src/main.rs
+++ b/intermediate/056/rust/src/main.rs
@@ -19,9 +19,20 @@ fn main() {
     println!("rad");
 }
 
-fn has_vowels_zero_mod_three(input: &str) -> bool {
+fn has_vowels_zero_mod_three_regex(input: &str) -> bool {
     let vowels = Regex::new(r"[aeiouy]").unwrap();
     vowels.find_iter(input).count() % 3 == 0
+}
+
+fn has_vowels_zero_mod_three_match(input: &str) -> bool {
+    let mut vowel_count = 0;
+    for character in input.chars() {
+        match character {
+            'a' | 'e' | 'i' | 'o' | 'u' | 'y' => vowel_count += 1,
+            _ => {}
+        }
+    }
+    vowel_count % 3 == 0
 }
 
 #[cfg(not(tarpaulin_include))]
@@ -30,16 +41,31 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_has_vowels_zero_mod_three() {
-        assert!(has_vowels_zero_mod_three(
+    fn test_has_vowels_zero_mod_three_regex() {
+        assert!(has_vowels_zero_mod_three_regex(
             "Friends, Romans, countrymen, lend me your ears!"
         ));
-        assert!(has_vowels_zero_mod_three(
+        assert!(has_vowels_zero_mod_three_regex(
             "Double, double, toil and trouble; Fire burn and cauldron bubble."
         ));
-        assert!(!has_vowels_zero_mod_three("Alas, poor Yorick! I knew him, Horatio. A fellow of infinite jest, of most excellent fancy."));
-        assert!(!has_vowels_zero_mod_three("To be, or not to be- that is the question: Whether 'tis nobler in the mind to suffer The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them."));
-        assert!(!has_vowels_zero_mod_three(
+        assert!(!has_vowels_zero_mod_three_regex("Alas, poor Yorick! I knew him, Horatio. A fellow of infinite jest, of most excellent fancy."));
+        assert!(!has_vowels_zero_mod_three_regex("To be, or not to be- that is the question: Whether 'tis nobler in the mind to suffer The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them."));
+        assert!(!has_vowels_zero_mod_three_regex(
+            "Everybody stand back! I know regular expressions."
+        ));
+    }
+
+    #[test]
+    fn test_has_vowels_zero_mod_three_match() {
+        assert!(has_vowels_zero_mod_three_match(
+            "Friends, Romans, countrymen, lend me your ears!"
+        ));
+        assert!(has_vowels_zero_mod_three_match(
+            "Double, double, toil and trouble; Fire burn and cauldron bubble."
+        ));
+        assert!(!has_vowels_zero_mod_three_match("Alas, poor Yorick! I knew him, Horatio. A fellow of infinite jest, of most excellent fancy."));
+        assert!(!has_vowels_zero_mod_three_match("To be, or not to be- that is the question: Whether 'tis nobler in the mind to suffer The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them."));
+        assert!(!has_vowels_zero_mod_three_match(
             "Everybody stand back! I know regular expressions."
         ));
     }

--- a/intermediate/056/rust/src/main.rs
+++ b/intermediate/056/rust/src/main.rs
@@ -27,7 +27,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_stub() {
-        assert_eq!(2 + 2, 4);
+    fn test_has_vowels_zero_mod_three() {
+        assert!(has_vowels_zero_mod_three(
+            "Friends, Romans, countrymen, lend me your ears!"
+        ));
+        assert!(has_vowels_zero_mod_three(
+            "Double, double, toil and trouble; Fire burn and cauldron bubble."
+        ));
+        assert!(!has_vowels_zero_mod_three("Alas, poor Yorick! I knew him, Horatio. A fellow of infinite jest, of most excellent fancy."));
+        assert!(!has_vowels_zero_mod_three("To be, or not to be- that is the question: Whether 'tis nobler in the mind to suffer The slings and arrows of outrageous fortune Or to take arms against a sea of troubles, And by opposing end them."));
+        assert!(!has_vowels_zero_mod_three(
+            "Everybody stand back! I know regular expressions."
+        ));
     }
 }

--- a/intermediate/056/rust/src/main.rs
+++ b/intermediate/056/rust/src/main.rs
@@ -17,6 +17,10 @@ fn main() {
     println!("rad");
 }
 
+fn has_vowels_zero_mod_three(input: &str) -> bool {
+    todo!()
+}
+
 #[cfg(not(tarpaulin_include))]
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
- Define intermediate #056
- Add boilerplate
- Create empty Rust file
- Define Rust package
- Stub prompt fnc
- Test has_vowels_zero_mod_three
- Implement has_vowels_zero_mod_three with regex
- Implement has_vowels_zero_mod_three without regex
