### PR TITLE
feat/intermediate 057

### DIFF
--- a/intermediate/057/README.md
+++ b/intermediate/057/README.md
@@ -1,0 +1,59 @@
+# [5/25/2012] Challenge #57 [intermediate]
+
+## Source
+
+[Original post](https://old.reddit.com/r/dailyprogrammer/comments/u4mki/5252012_challenge_57_intermediate/)
+
+## Prompt
+
+ Given a 3x3 table where 1 represents on and 0 represents off:
+
+ ABC
+A010
+B111
+C011
+
+Where "inverted match" is defined as a case where the values at the coordinates in the format of (X, Y) and (Y, X) are the same, the inverted matches are as follows:
+
+[[(A, B), (B, A)], [(A, C), (C, A)], [(B, C), (C, B)]]
+
+Of these, the matches that have a value of 1 are:
+
+[[(A, B), (B, A)], [(B, C), (C, B)]]
+
+Therefore, there are 2 sets of inverted matches that have a value of 1.
+
+Find the amount of inverted matches in the table in table(below) with a value of 1.
+_________________________
+
+Table:
+
+` ABCDEFGHIJKLMNOPQRST`
+`A11110101111011100010`
+`B10010010000010001100`
+`C01101110010001000000`
+`D10110011001011101100`
+`E10100100011110110100`
+`F01111011000111010010`
+`G00011110001011001110`
+`H01111000010001001000`
+`I01101110010110010011`
+`J00101000100010011110`
+`K10101001100001100000`
+`L01011010011101100110`
+`M10110110010101000100`
+`N10001111101111110010`
+`O11011010010111100110`
+`P01000110111101101000`
+`Q10011001100010100000`
+`R11101011100110110110`
+`S00001100000110010101`
+`T01000110011100101011`
+
+_______________________
+
+* Thanks to gbchaosmaster for the challenge at /r/dailyprogrammer_ideas :)
+
+__________________________
+
+**UPDATE:** I have given some more info on the difficult challenge since it seems to be very tough. you have upto monday to finish all these challenges. pls note it :)

--- a/intermediate/057/rust/Cargo.toml
+++ b/intermediate/057/rust/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "intermediate_057"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+#itertools = "0.10.3"
+#lazy_static = "1.4.0"
+#rand = "0.8.4"
+#rand_pcg = "0.3.1"
+#regex = "1"

--- a/intermediate/057/rust/Makefile
+++ b/intermediate/057/rust/Makefile
@@ -1,0 +1,6 @@
+# Aliases for executables
+GIT ?= git
+
+INCLUDE_PATH = $(shell git rev-parse --show-toplevel)/rust.mk
+
+include $(INCLUDE_PATH)

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -15,9 +15,10 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
+#[derive(Debug, PartialEq, Eq)]
 struct InvertedMatchTable {
-    rows: HashMap<char, u8>,
-    columns: HashMap<char, u8>,
+    rows: HashMap<char, HashMap<char, u8>>,
+    columns: HashMap<char, HashMap<char, u8>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -45,7 +46,57 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_stub() {
-        assert_eq!(2 + 2, 4);
+    fn test_invertedmatchtable_from_str() {
+        //  ABC
+        // A010
+        // B111
+        // C011
+        let result = InvertedMatchTable {
+            rows: HashMap::from_iter(vec![
+                ('A', HashMap::from_iter(vec![('A', 0), ('B', 1), ('C', 0)])),
+                ('B', HashMap::from_iter(vec![('A', 1), ('B', 1), ('C', 1)])),
+                ('C', HashMap::from_iter(vec![('A', 0), ('B', 1), ('C', 1)])),
+            ]),
+            columns: HashMap::from_iter(vec![
+                ('A', HashMap::from_iter(vec![('A', 0), ('B', 1), ('C', 0)])),
+                ('B', HashMap::from_iter(vec![('A', 1), ('B', 1), ('C', 1)])),
+                ('C', HashMap::from_iter(vec![('A', 0), ('B', 1), ('C', 1)])),
+            ]),
+        };
+        assert_eq!(
+            result,
+            InvertedMatchTable::from_str(" ABC\nA010\nB111\nC011").unwrap()
+        );
+        //  ABCDEFGHIJKLMNOPQRST
+        // A11110101111011100010
+        // B10010010000010001100
+        // C01101110010001000000
+        // D10110011001011101100
+        // E10100100011110110100
+        // F01111011000111010010
+        // G00011110001011001110
+        // H01111000010001001000
+        // I01101110010110010011
+        // J00101000100010011110
+        // K10101001100001100000
+        // L01011010011101100110
+        // M10110110010101000100
+        // N10001111101111110010
+        // O11011010010111100110
+        // P01000110111101101000
+        // Q10011001100010100000
+        // R11101011100110110110
+        // S00001100000110010101
+        // T01000110011100101011
+        let big_table = InvertedMatchTable::from_str(" ABCDEFGHIJKLMNOPQRST\nA11110101111011100010\nB10010010000010001100\nC01101110010001000000\nD10110011001011101100\nE10100100011110110100\nF01111011000111010010\nG00011110001011001110\nH01111000010001001000\nI01101110010110010011\nJ00101000100010011110\nK10101001100001100000\nL01011010011101100110\nM10110110010101000100\nN10001111101111110010\nO11011010010111100110\nP01000110111101101000\nQ10011001100010100000\nR11101011100110110110\nS00001100000110010101\nT01000110011100101011").unwrap();
+        let a_row = big_table.rows.get(&'A').unwrap();
+        assert_eq!(1, *a_row.get(&'A').unwrap());
+        assert_eq!(1, *a_row.get(&'B').unwrap());
+        assert_eq!(1, *a_row.get(&'C').unwrap());
+        assert_eq!(1, *a_row.get(&'D').unwrap());
+        assert_eq!(0, *a_row.get(&'E').unwrap());
+        assert_eq!(1, *a_row.get(&'F').unwrap());
+        assert_eq!(0, *a_row.get(&'G').unwrap());
+        assert_eq!(1, *a_row.get(&'H').unwrap());
     }
 }

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -28,10 +28,29 @@ impl FromStr for InvertedMatchTable {
     type Err = ParseInvertedMatchTableError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // let mut rows = HashMap::new();
-        // let mut columns = HashMap::new();
-        // Ok(InvertedMatchTable { rows, columns })
-        todo!()
+        let mut rows = HashMap::new();
+        let mut columns = HashMap::new();
+        let mut lines = s.lines();
+        let header = lines.next().unwrap();
+        let header_chars: Vec<char> = header.chars().collect();
+        for line in lines {
+            let line_chars: Vec<char> = line.chars().collect();
+            let row_char = line_chars[0];
+            let mut row = HashMap::new();
+            for (index, column_char) in line_chars.iter().enumerate().skip(1) {
+                let header_char = header_chars[index];
+                row.insert(header_char, *column_char as u8 - 48);
+                if !columns.contains_key(&header_char) {
+                    columns.insert(header_char, HashMap::new());
+                }
+                columns
+                    .get_mut(&header_char)
+                    .unwrap()
+                    .insert(row_char, *column_char as u8 - 48);
+            }
+            rows.insert(row_char, row);
+        }
+        Ok(InvertedMatchTable { rows, columns })
     }
 }
 

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+
+struct InvertedMatchTable {
+    rows: HashMap<char, u8>,
+    columns: HashMap<char, u8>,
+}
+
 #[cfg(not(tarpaulin_include))]
 fn main() {
     println!("rad");

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -124,4 +124,13 @@ mod tests {
         assert_eq!(0, *a_row.get(&'G').unwrap());
         assert_eq!(1, *a_row.get(&'H').unwrap());
     }
+
+    #[test]
+    fn test_invertedmatchtable_find_inverted_matches() {
+        let table = InvertedMatchTable::from_str(" ABC\nA010\nB111\nC011").unwrap();
+        assert_eq!(
+            vec![(('A', 'B'), ('B', 'A')), (('B', 'C'), ('C', 'B'))],
+            table.find_inverted_matches()
+        );
+    }
 }

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -56,7 +56,19 @@ impl FromStr for InvertedMatchTable {
 
 impl InvertedMatchTable {
     fn find_inverted_matches(&self) -> Vec<((char, char), (char, char))> {
-        todo!()
+        let mut matches = Vec::new();
+        let characters = self.rows.keys().collect::<Vec<&char>>();
+        for (row_char, index) in characters.iter().enumerate() {
+            for column_char in characters.iter().skip(row_char + 1) {
+                let row_val = self.rows.get(*index).unwrap().get(*column_char).unwrap();
+                let column_val = self.columns.get(*column_char).unwrap().get(*index).unwrap();
+                if 1 == *row_val && 1 == *column_val {
+                    matches.push(((**index, **column_char), (**column_char, **index)));
+                }
+            }
+        }
+        matches.sort();
+        matches
     }
 }
 

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -54,6 +54,12 @@ impl FromStr for InvertedMatchTable {
     }
 }
 
+impl InvertedMatchTable {
+    fn find_inverted_matches(&self) -> Vec<((char, char), (char, char))> {
+        todo!()
+    }
+}
+
 #[cfg(not(tarpaulin_include))]
 fn main() {
     println!("rad");

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -1,0 +1,29 @@
+// Copyright 2023 CJ Harries
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(not(tarpaulin_include))]
+fn main() {
+    println!("rad");
+}
+
+#[cfg(not(tarpaulin_include))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stub() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Eq)]
 struct InvertedMatchTable {
-    rows: HashMap<char, HashMap<char, u8>>,
-    columns: HashMap<char, HashMap<char, u8>>,
+    characters: Vec<char>,
+    coordinates: Vec<Vec<u8>>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -28,50 +27,45 @@ impl FromStr for InvertedMatchTable {
     type Err = ParseInvertedMatchTableError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut rows = HashMap::new();
-        let mut columns = HashMap::new();
-        let mut lines = s.lines();
-        let header = lines.next().unwrap();
-        let header_chars: Vec<char> = header.chars().collect();
-        for line in lines {
-            let line_chars: Vec<char> = line.chars().collect();
-            let row_char = line_chars[0];
-            let mut row = HashMap::new();
-            for (index, column_char) in line_chars.iter().enumerate().skip(1) {
-                let header_char = header_chars[index];
-                row.insert(header_char, *column_char as u8 - 48);
-                if !columns.contains_key(&header_char) {
-                    columns.insert(header_char, HashMap::new());
-                }
-                columns
-                    .get_mut(&header_char)
-                    .unwrap()
-                    .insert(row_char, *column_char as u8 - 48);
+        let mut characters = Vec::new();
+        let mut coordinates = Vec::new();
+        for (row_index, row) in s.split('\n').enumerate() {
+            if 0 == row_index {
+                characters = row.chars().filter(|c| c.is_alphabetic()).collect();
+            } else {
+                coordinates.push(
+                    row.chars()
+                        .filter(|c| c.is_numeric())
+                        .map(|character| character.to_digit(10).unwrap() as u8)
+                        .collect(),
+                );
             }
-            rows.insert(row_char, row);
         }
-        Ok(InvertedMatchTable { rows, columns })
+        Ok(InvertedMatchTable {
+            characters,
+            coordinates,
+        })
     }
 }
 
-impl InvertedMatchTable {
-    fn find_inverted_matches(&self) -> Vec<((char, char), (char, char))> {
-        let mut matches = Vec::new();
-        let mut characters = self.rows.keys().collect::<Vec<&char>>();
-        characters.sort();
-        for (row_char, index) in characters.iter().enumerate() {
-            for column_char in characters.iter().skip(row_char + 1) {
-                let row_val = self.rows.get(*index).unwrap().get(*column_char).unwrap();
-                let column_val = self.columns.get(*column_char).unwrap().get(*index).unwrap();
-                if 1 == *row_val && 1 == *column_val {
-                    matches.push(((**index, **column_char), (**column_char, **index)));
-                }
-            }
-        }
-        matches.sort();
-        matches
-    }
-}
+// impl InvertedMatchTable {
+//     fn find_inverted_matches(&self) -> Vec<((char, char), (char, char))> {
+//         let mut matches = Vec::new();
+//         let mut characters = self.rows.keys().collect::<Vec<&char>>();
+//         characters.sort();
+//         for (row_char, index) in characters.iter().enumerate() {
+//             for column_char in characters.iter().skip(row_char + 1) {
+//                 let row_val = self.rows.get(*index).unwrap().get(*column_char).unwrap();
+//                 let column_val = self.columns.get(*column_char).unwrap().get(*index).unwrap();
+//                 if 1 == *row_val && 1 == *column_val {
+//                     matches.push(((**index, **column_char), (**column_char, **index)));
+//                 }
+//             }
+//         }
+//         matches.sort();
+//         matches
+//     }
+// }
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
@@ -90,16 +84,8 @@ mod tests {
         // B111
         // C011
         let result = InvertedMatchTable {
-            rows: HashMap::from_iter(vec![
-                ('A', HashMap::from_iter(vec![('A', 0), ('B', 1), ('C', 0)])),
-                ('B', HashMap::from_iter(vec![('A', 1), ('B', 1), ('C', 1)])),
-                ('C', HashMap::from_iter(vec![('A', 0), ('B', 1), ('C', 1)])),
-            ]),
-            columns: HashMap::from_iter(vec![
-                ('A', HashMap::from_iter(vec![('A', 0), ('B', 1), ('C', 0)])),
-                ('B', HashMap::from_iter(vec![('A', 1), ('B', 1), ('C', 1)])),
-                ('C', HashMap::from_iter(vec![('A', 0), ('B', 1), ('C', 1)])),
-            ]),
+            characters: vec!['A', 'B', 'C'],
+            coordinates: vec![vec![0, 1, 0], vec![1, 1, 1], vec![0, 1, 1]],
         };
         assert_eq!(
             result,
@@ -127,25 +113,27 @@ mod tests {
         // S00001100000110010101
         // T01000110011100101011
         let big_table = InvertedMatchTable::from_str(" ABCDEFGHIJKLMNOPQRST\nA11110101111011100010\nB10010010000010001100\nC01101110010001000000\nD10110011001011101100\nE10100100011110110100\nF01111011000111010010\nG00011110001011001110\nH01111000010001001000\nI01101110010110010011\nJ00101000100010011110\nK10101001100001100000\nL01011010011101100110\nM10110110010101000100\nN10001111101111110010\nO11011010010111100110\nP01000110111101101000\nQ10011001100010100000\nR11101011100110110110\nS00001100000110010101\nT01000110011100101011").unwrap();
-        let a_row = big_table.rows.get(&'A').unwrap();
-        assert_eq!(1, *a_row.get(&'A').unwrap());
-        assert_eq!(1, *a_row.get(&'B').unwrap());
-        assert_eq!(1, *a_row.get(&'C').unwrap());
-        assert_eq!(1, *a_row.get(&'D').unwrap());
-        assert_eq!(0, *a_row.get(&'E').unwrap());
-        assert_eq!(1, *a_row.get(&'F').unwrap());
-        assert_eq!(0, *a_row.get(&'G').unwrap());
-        assert_eq!(1, *a_row.get(&'H').unwrap());
+        assert_eq!(
+            vec![
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+                'Q', 'R', 'S', 'T'
+            ],
+            big_table.characters
+        );
+        assert_eq!(
+            vec![1, 1, 1, 1, 0, 1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 1, 0],
+            big_table.coordinates[0]
+        );
     }
 
-    #[test]
-    fn test_invertedmatchtable_find_inverted_matches() {
-        let table = InvertedMatchTable::from_str(" ABC\nA010\nB111\nC011").unwrap();
-        assert_eq!(
-            vec![(('A', 'B'), ('B', 'A')), (('B', 'C'), ('C', 'B'))],
-            table.find_inverted_matches()
-        );
-        let big_table = InvertedMatchTable::from_str(" ABCDEFGHIJKLMNOPQRST\nA11110101111011100010\nB10010010000010001100\nC01101110010001000000\nD10110011001011101100\nE10100100011110110100\nF01111011000111010010\nG00011110001011001110\nH01111000010001001000\nI01101110010110010011\nJ00101000100010011110\nK10101001100001100000\nL01011010011101100110\nM10110110010101000100\nN10001111101111110010\nO11011010010111100110\nP01000110111101101000\nQ10011001100010100000\nR11101011100110110110\nS00001100000110010101\nT01000110011100101011").unwrap();
-        assert_eq!(47, big_table.find_inverted_matches().len());
-    }
+    // #[test]
+    // fn test_invertedmatchtable_find_inverted_matches() {
+    //     let table = InvertedMatchTable::from_str(" ABC\nA010\nB111\nC011").unwrap();
+    //     assert_eq!(
+    //         vec![(('A', 'B'), ('B', 'A')), (('B', 'C'), ('C', 'B'))],
+    //         table.find_inverted_matches()
+    //     );
+    //     let big_table = InvertedMatchTable::from_str(" ABCDEFGHIJKLMNOPQRST\nA11110101111011100010\nB10010010000010001100\nC01101110010001000000\nD10110011001011101100\nE10100100011110110100\nF01111011000111010010\nG00011110001011001110\nH01111000010001001000\nI01101110010110010011\nJ00101000100010011110\nK10101001100001100000\nL01011010011101100110\nM10110110010101000100\nN10001111101111110010\nO11011010010111100110\nP01000110111101101000\nQ10011001100010100000\nR11101011100110110110\nS00001100000110010101\nT01000110011100101011").unwrap();
+    //     assert_eq!(47, big_table.find_inverted_matches().len());
+    // }
 }

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -57,7 +57,8 @@ impl FromStr for InvertedMatchTable {
 impl InvertedMatchTable {
     fn find_inverted_matches(&self) -> Vec<((char, char), (char, char))> {
         let mut matches = Vec::new();
-        let characters = self.rows.keys().collect::<Vec<&char>>();
+        let mut characters = self.rows.keys().collect::<Vec<&char>>();
+        characters.sort();
         for (row_char, index) in characters.iter().enumerate() {
             for column_char in characters.iter().skip(row_char + 1) {
                 let row_val = self.rows.get(*index).unwrap().get(*column_char).unwrap();
@@ -144,5 +145,7 @@ mod tests {
             vec![(('A', 'B'), ('B', 'A')), (('B', 'C'), ('C', 'B'))],
             table.find_inverted_matches()
         );
+        let big_table = InvertedMatchTable::from_str(" ABCDEFGHIJKLMNOPQRST\nA11110101111011100010\nB10010010000010001100\nC01101110010001000000\nD10110011001011101100\nE10100100011110110100\nF01111011000111010010\nG00011110001011001110\nH01111000010001001000\nI01101110010110010011\nJ00101000100010011110\nK10101001100001100000\nL01011010011101100110\nM10110110010101000100\nN10001111101111110010\nO11011010010111100110\nP01000110111101101000\nQ10011001100010100000\nR11101011100110110110\nS00001100000110010101\nT01000110011100101011").unwrap();
+        assert_eq!(47, big_table.find_inverted_matches().len());
     }
 }

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -13,10 +13,25 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::str::FromStr;
 
 struct InvertedMatchTable {
     rows: HashMap<char, u8>,
     columns: HashMap<char, u8>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ParseInvertedMatchTableError;
+
+impl FromStr for InvertedMatchTable {
+    type Err = ParseInvertedMatchTableError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // let mut rows = HashMap::new();
+        // let mut columns = HashMap::new();
+        // Ok(InvertedMatchTable { rows, columns })
+        todo!()
+    }
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/intermediate/057/rust/src/main.rs
+++ b/intermediate/057/rust/src/main.rs
@@ -48,24 +48,22 @@ impl FromStr for InvertedMatchTable {
     }
 }
 
-// impl InvertedMatchTable {
-//     fn find_inverted_matches(&self) -> Vec<((char, char), (char, char))> {
-//         let mut matches = Vec::new();
-//         let mut characters = self.rows.keys().collect::<Vec<&char>>();
-//         characters.sort();
-//         for (row_char, index) in characters.iter().enumerate() {
-//             for column_char in characters.iter().skip(row_char + 1) {
-//                 let row_val = self.rows.get(*index).unwrap().get(*column_char).unwrap();
-//                 let column_val = self.columns.get(*column_char).unwrap().get(*index).unwrap();
-//                 if 1 == *row_val && 1 == *column_val {
-//                     matches.push(((**index, **column_char), (**column_char, **index)));
-//                 }
-//             }
-//         }
-//         matches.sort();
-//         matches
-//     }
-// }
+impl InvertedMatchTable {
+    fn find_inverted_matches(&self) -> Vec<((char, char), (char, char))> {
+        let mut matches = Vec::new();
+        for column in 0..self.coordinates.len() {
+            for row in 0..column {
+                if 1 == self.coordinates[row][column] && 1 == self.coordinates[column][row] {
+                    matches.push((
+                        (self.characters[row], self.characters[column]),
+                        (self.characters[column], self.characters[row]),
+                    ));
+                }
+            }
+        }
+        matches
+    }
+}
 
 #[cfg(not(tarpaulin_include))]
 fn main() {
@@ -126,14 +124,14 @@ mod tests {
         );
     }
 
-    // #[test]
-    // fn test_invertedmatchtable_find_inverted_matches() {
-    //     let table = InvertedMatchTable::from_str(" ABC\nA010\nB111\nC011").unwrap();
-    //     assert_eq!(
-    //         vec![(('A', 'B'), ('B', 'A')), (('B', 'C'), ('C', 'B'))],
-    //         table.find_inverted_matches()
-    //     );
-    //     let big_table = InvertedMatchTable::from_str(" ABCDEFGHIJKLMNOPQRST\nA11110101111011100010\nB10010010000010001100\nC01101110010001000000\nD10110011001011101100\nE10100100011110110100\nF01111011000111010010\nG00011110001011001110\nH01111000010001001000\nI01101110010110010011\nJ00101000100010011110\nK10101001100001100000\nL01011010011101100110\nM10110110010101000100\nN10001111101111110010\nO11011010010111100110\nP01000110111101101000\nQ10011001100010100000\nR11101011100110110110\nS00001100000110010101\nT01000110011100101011").unwrap();
-    //     assert_eq!(47, big_table.find_inverted_matches().len());
-    // }
+    #[test]
+    fn test_invertedmatchtable_find_inverted_matches() {
+        let table = InvertedMatchTable::from_str(" ABC\nA010\nB111\nC011").unwrap();
+        assert_eq!(
+            vec![(('A', 'B'), ('B', 'A')), (('B', 'C'), ('C', 'B'))],
+            table.find_inverted_matches()
+        );
+        let big_table = InvertedMatchTable::from_str(" ABCDEFGHIJKLMNOPQRST\nA11110101111011100010\nB10010010000010001100\nC01101110010001000000\nD10110011001011101100\nE10100100011110110100\nF01111011000111010010\nG00011110001011001110\nH01111000010001001000\nI01101110010110010011\nJ00101000100010011110\nK10101001100001100000\nL01011010011101100110\nM10110110010101000100\nN10001111101111110010\nO11011010010111100110\nP01000110111101101000\nQ10011001100010100000\nR11101011100110110110\nS00001100000110010101\nT01000110011100101011").unwrap();
+        assert_eq!(47, big_table.find_inverted_matches().len());
+    }
 }


### PR DESCRIPTION
- Define intermediate #057
- Add boilerplate
- Create empty Rust file
- Define Rust package
- Define type
- Stub InvertedMatchTable::from_str
- Test InvertedMatchTable::from_str
- Implement InvertedMatchTable::from_str
- Stub prompt fnc
- Test InvertedMatchTable::find_inverted_matches
- Implement InvertedMatchTable::find_inverted_matches
- Implement prompt test
- Refactor with new data structure
- Reimplement find_inverted_matches with simpler data structure
