### PR TITLE
feat/intermediate 132

### DIFF
--- a/intermediate/132/README.md
+++ b/intermediate/132/README.md
@@ -1,0 +1,113 @@
+# [08/08/13] Challenge #132 [Intermediate] Tiny Assembler
+
+## Source
+
+[Original post](https://old.reddit.com/r/dailyprogrammer/comments/1kqxz9/080813_challenge_132_intermediate_tiny_assembler/)
+
+## Prompt
+
+# [](#IntermediateIcon) *(Intermediate)*: Tiny Assembler
+
+*Tiny*, a very simple fictional computer architecture, is programmed by an assembly language that has 16 [mnemonics](http://en.wikipedia.org/wiki/Assembly_language#Opcode_mnemonics_and_extended_mnemonics), with 37 unique op-codes. The system is based on [Harvard architecture](http://en.wikipedia.org/wiki/Harvard_architecture), and is very straight-forward: program memory is different from working memory, the machine only executes one instruction at a time, memory is an array of bytes from index 0 to index 255 (inclusive), and doesn't have any relative addressing modes. Instructions are multibyte, much like the X86 architecture. Simple instructions like HALT only take one byte, while complex instructions like JLS (Jump if Less-than) take four bytes.
+
+Your goal will be to write an [assembler](http://en.wikipedia.org/wiki/Assembler_(computing\)#Assembler) for Tiny: though you don't need to simulate the code or machine components, you must take given assembly-language source code and produce a list of hex op-codes. You are essentially writing code that converts the lowest human-readable language to machine-readable language!
+
+The following are all mnemonics and associated op-codes for the Tiny machine. Note that brackets mean "content of address-index" while non-brackets mean literals. For example, the instruction "AND [0] 1" will set the contents of the first element (at index 0) of memory to 1 if, and only if, the original contents at that element are equal to the given literal 1.
+
+**Google Documents of the below [found here](https://docs.google.com/document/d/1lDk_1dLz82iwc-1hESNFSepcz4Swyaf9P1j5hvR2iHw).**
+
+|	Group	|	Instruction	|	Byte Code	|	Description	|
+|	:-----------	|	:-----------	|	:-----------	|	:-----------	|
+|	1. Logic	|	AND a b	|	2 Ops, 3 bytes:	|	M[a] = M[a] bit-wise and M[b]	|
+|		|		|	0x00 [a] [b]	|		|
+|		|		|	0x01 [a] b	|		|
+|		|	OR a b	|	2 Ops, 3 bytes:	|	M[a] = M[a] bit-wise or M[b]	|
+|		|		|	0x02 [a] [b]	|		|
+|		|		|	0x03 [a] b	|		|
+|		|	XOR a b	|	2 Ops, 3 bytes:	|	M[a] = M[a] bit-wise xor M[b]	|
+|		|		|	0x04 [a] [b]	|		|
+|		|		|	0x05 [a] b	|		|
+|		|	NOT a	|	1 Op, 2 bytes:	|	M[a] = bit-wise not M[a]	|
+|		|		|	0x06 [a]	|		|
+|	2. Memory	|	MOV a b	|	2 Ops, 3 bytes:	|	M[a] = M[b], or the literal-set M[a] = b	|
+|		|		|	0x07 [a] [b]	|		|
+|		|		|	0x08 [a] b	|		|
+|	3. Math	|	RANDOM a	|	2 Ops, 2 bytes:	|	M[a] = random value (0 to 25; equal probability distribution)	|
+|		|		|	0x09 [a]	|		|
+|		|	ADD a b	|	2 Ops, 3 bytes:	|	M[a] = M[a] + b; no overflow support	|
+|		|		|	0x0a [a] [b]	|		|
+|		|		|	0x0b [a] b	|		|
+|		|	SUB a b	|	2 Ops, 3 bytes:	|	M[a] = M[a] - b; no underflow support	|
+|		|		|	0x0c [a] [b]	|		|
+|		|		|	0x0d [a] b	|		|
+|	4. Control	|	JMP x	|	2 Ops, 2 bytes:	|	Start executing instructions at index of value M[a] (So given a is zero, and M[0] is 10, we then execute instruction 10) or the literal a-value	|
+|		|		|	0x0e [x]	|		|
+|		|		|	0x0f x	|		|
+|		|	JZ x a	|	4 Ops, 3 bytes:	|	Start executing instructions at index x if M[a] == 0 (This is a nice short-hand version of )	|
+|		|		|	0x10 [x] [a]	|		|
+|		|		|	0x11 [x] a	|		|
+|		|		|	0x12 x [a]	|		|
+|		|		|	0x13 x a	|		|
+|		|	JEQ x a b	|	4 Ops, 4 bytes:	|	Jump to x or M[x] if M[a] is equal to M[b] or if M[a] is equal to the literal b.	|
+|		|		|	0x14 [x] [a] [b]	|		|
+|		|		|	0x15 x [a] [b]	|		|
+|		|		|	0x16 [x] [a] b	|		|
+|		|		|	0x17 x [a] b	|		|
+|		|	JLS x a b	|	4 Ops, 4 bytes:	|	Jump to x or M[x] if M[a] is less than M[b] or if M[a] is less than the literal b.	|
+|		|		|	0x18 [x] [a] [b]	|		|
+|		|		|	0x19 x [a] [b]	|		|
+|		|		|	0x1a [x] [a] b	|		|
+|		|		|	0x1b x [a] b	|		|
+|		|	JGT x a b	|	4 Ops, 4 bytes:	|	Jump to x or M[x] if M[a] is greater than M[b] or if M[a] is greater than the literal b.	|
+|		|		|	0x1c [x] [a] [b]	|		|
+|		|		|	0x1d x [a] [b]	|		|
+|		|		|	0x1e [x] [a] b	|		|
+|		|		|	0x1f x [a] b	|		|
+|		|	HALT	|	1 Op, 1 byte:	|	Halts the program / freeze flow of execution	|
+|		|		|	0xff	|		|
+|	5. Utilities	|	APRINT a	|	4 Ops, 2 byte:	|	Print the contents of M[a] in either ASCII (if using APRINT) or as decimal (if using DPRINT). Memory ref or literals are supported in both instructions.	|
+|		|	DPRINT a	|	0x20 [a] (as ASCII; aprint)	|		|
+|		|		|	0x21 a (as ASCII)	|		|
+|		|		|	0x22 [a] (as Decimal; dprint)	|		|
+|		|		|	0x23 a (as Decimal)	|		|
+
+
+*Original author: /u/nint22*
+
+# Formal Inputs & Outputs
+## Input Description
+
+You will be given the contents of a file of Tiny assembly-language source code. This text file will only contain source-code, and no meta-data or comments. The source code is not case-sensitive, so the instruction "and", "And", and "AND" are all the same.
+
+## Output Description
+
+Print the resulting op-codes in hexadecimal value. Formatting does not matter, as long as you print the *correct* hex-code!
+
+# Sample Inputs & Outputs
+## Sample Input
+
+*The following Tiny assembly-language code will multiply the numbers at memory-location 0 and 1, putting the result at memory-location 0, while using [2] and [3] as working variables. All of this is done at the lowest 4 bytes of memory.*
+
+    Mov [2] 0
+    Mov [3] 0
+    Jeq 6 [3] [1]
+    Add [3] 1
+    Add [2] [0]
+    Jmp 2
+    Mov [0] [2]
+    Halt
+
+## Sample Output
+
+    0x08 0x02 0x00
+    0x08 0x03 0x00
+    0x15 0x06 0x03 0x01
+    0x0B 0x03 0x01
+    0x0A 0x02 0x00
+    0x0F 0x02
+    0x07 0x00 0x02
+    0xFF
+
+# Challenge Bonus
+
+If you write an interesting Tiny-language program and successfully run it against your assembler, you'll win a silver medal! If you can formally prove (it won't take much effort) that this language / machine is Turing Complete, you'll win a gold medal!

--- a/intermediate/132/rust/Cargo.toml
+++ b/intermediate/132/rust/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "intermediate_132"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+#itertools = "0.10.3"
+#lazy_static = "1.4.0"
+#rand = "0.8.4"
+#rand_pcg = "0.3.1"
+#regex = "1"

--- a/intermediate/132/rust/Makefile
+++ b/intermediate/132/rust/Makefile
@@ -1,0 +1,6 @@
+# Aliases for executables
+GIT ?= git
+
+INCLUDE_PATH = $(shell git rev-parse --show-toplevel)/rust.mk
+
+include $(INCLUDE_PATH)

--- a/intermediate/132/rust/src/main.rs
+++ b/intermediate/132/rust/src/main.rs
@@ -12,6 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[derive(Debug, PartialEq)]
+enum TinyInstructions {
+    And,
+    Or,
+    Xor,
+    Not,
+    Mov,
+    Random,
+    Add,
+    Sub,
+    Jump,
+    Jz,
+    Jeq,
+    Jls,
+    Jgt,
+    Halt,
+    Aprint,
+    Dprint,
+}
+
 #[cfg(not(tarpaulin_include))]
 fn main() {
     println!("rad");

--- a/intermediate/132/rust/src/main.rs
+++ b/intermediate/132/rust/src/main.rs
@@ -19,23 +19,24 @@ enum TinyInput {
 }
 
 #[derive(Debug, PartialEq)]
+#[repr(u8)]
 enum TinyInstructions {
-    And = 0x00,
-    Or = 0x02,
-    Xor = 0x04,
-    Not = 0x06,
-    Mov = 0x07,
-    Random = 0x09,
-    Add = 0x0a,
-    Sub = 0x0c,
-    Jump = 0x0e,
-    Jz = 0x10,
-    Jeq = 0x14,
-    Jls = 0x18,
-    Jgt = 0x1c,
+    And(TinyInput, TinyInput) = 0x00,
+    Or(TinyInput, TinyInput) = 0x02,
+    Xor(TinyInput, TinyInput) = 0x04,
+    Not(TinyInput) = 0x06,
+    Mov(TinyInput, TinyInput) = 0x07,
+    Random(TinyInput) = 0x09,
+    Add(TinyInput, TinyInput) = 0x0a,
+    Sub(TinyInput, TinyInput) = 0x0c,
+    Jump(TinyInput) = 0x0e,
+    Jz(TinyInput, TinyInput) = 0x10,
+    Jeq(TinyInput, TinyInput, TinyInput) = 0x14,
+    Jls(TinyInput, TinyInput, TinyInput) = 0x18,
+    Jgt(TinyInput, TinyInput, TinyInput) = 0x1c,
     Halt = 0xff,
     Aprint = 0x20,
-    Dprint = 0x21,
+    Dprint(TinyInput) = 0x21,
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/intermediate/132/rust/src/main.rs
+++ b/intermediate/132/rust/src/main.rs
@@ -118,6 +118,8 @@ impl TinyInstructions {
 }
 
 impl std::fmt::Display for TinyInstructions {
+    // Note I don't take into account any of the different instruction values
+    // For a complete solution I'd need to check the value types
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::And(left, right) => write!(f, "0x00 {} {}", left, right),

--- a/intermediate/132/rust/src/main.rs
+++ b/intermediate/132/rust/src/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 #[repr(u8)]
 enum TinyInput {
     Register(u8),
@@ -37,7 +37,7 @@ impl std::fmt::Display for TinyInput {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Copy, Clone)]
 #[repr(u8)]
 enum TinyInstructions {
     And(TinyInput, TinyInput) = 0x00,
@@ -113,6 +113,29 @@ impl TinyInstructions {
             "aprint" => Self::Aprint,
             "dprint" => Self::Dprint(TinyInput::new(split.next().unwrap())),
             _ => panic!("Invalid instruction"),
+        }
+    }
+}
+
+impl std::fmt::Display for TinyInstructions {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::And(left, right) => write!(f, "0x00 {} {}", left, right),
+            Self::Or(left, right) => write!(f, "0x02 {} {}", left, right),
+            Self::Xor(left, right) => write!(f, "0x04 {} {}", left, right),
+            Self::Not(value) => write!(f, "0x06 {}", value),
+            Self::Mov(left, right) => write!(f, "0x07 {} {}", left, right),
+            Self::Random(value) => write!(f, "0x09 {}", value),
+            Self::Add(left, right) => write!(f, "0x0a {} {}", left, right),
+            Self::Sub(left, right) => write!(f, "0x0c {} {}", left, right),
+            Self::Jump(value) => write!(f, "0x0e {}", value),
+            Self::Jz(left, right) => write!(f, "0x10 {} {}", left, right),
+            Self::Jeq(left, middle, right) => write!(f, "0x14 {} {} {}", left, middle, right),
+            Self::Jls(left, middle, right) => write!(f, "0x18 {} {} {}", left, middle, right),
+            Self::Jgt(left, middle, right) => write!(f, "0x1c {} {} {}", left, middle, right),
+            Self::Halt => write!(f, "0xff"),
+            Self::Aprint => write!(f, "0x20"),
+            Self::Dprint(value) => write!(f, "0x21 {}", value),
         }
     }
 }
@@ -235,5 +258,109 @@ mod tests {
     #[should_panic]
     fn tinyinstructions_errors_with_unknown_instruction() {
         TinyInstructions::new("unknown");
+    }
+
+    #[test]
+    fn tinyinstructions_can_print_all_instructions() {
+        assert_eq!(
+            format!(
+                "{}",
+                TinyInstructions::And(TinyInput::Register(0), TinyInput::Value(1))
+            ),
+            "0x00 0x00 0x01"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                TinyInstructions::Or(TinyInput::Register(0), TinyInput::Value(1))
+            ),
+            "0x02 0x00 0x01"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                TinyInstructions::Xor(TinyInput::Register(0), TinyInput::Value(1))
+            ),
+            "0x04 0x00 0x01"
+        );
+        assert_eq!(
+            format!("{}", TinyInstructions::Not(TinyInput::Register(0))),
+            "0x06 0x00"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                TinyInstructions::Mov(TinyInput::Register(0), TinyInput::Value(1))
+            ),
+            "0x07 0x00 0x01"
+        );
+        assert_eq!(
+            format!("{}", TinyInstructions::Random(TinyInput::Register(0))),
+            "0x09 0x00"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                TinyInstructions::Add(TinyInput::Register(0), TinyInput::Value(1))
+            ),
+            "0x0a 0x00 0x01"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                TinyInstructions::Sub(TinyInput::Register(0), TinyInput::Value(1))
+            ),
+            "0x0c 0x00 0x01"
+        );
+        assert_eq!(
+            format!("{}", TinyInstructions::Jump(TinyInput::Register(0))),
+            "0x0e 0x00"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                TinyInstructions::Jz(TinyInput::Register(0), TinyInput::Value(1))
+            ),
+            "0x10 0x00 0x01"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                TinyInstructions::Jeq(
+                    TinyInput::Register(0),
+                    TinyInput::Value(1),
+                    TinyInput::Value(2)
+                )
+            ),
+            "0x14 0x00 0x01 0x02"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                TinyInstructions::Jls(
+                    TinyInput::Register(0),
+                    TinyInput::Value(1),
+                    TinyInput::Value(2)
+                )
+            ),
+            "0x18 0x00 0x01 0x02"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                TinyInstructions::Jgt(
+                    TinyInput::Register(0),
+                    TinyInput::Value(1),
+                    TinyInput::Value(2)
+                )
+            ),
+            "0x1c 0x00 0x01 0x02"
+        );
+        assert_eq!(format!("{}", TinyInstructions::Halt), "0xff");
+        assert_eq!(format!("{}", TinyInstructions::Aprint), "0x20");
+        assert_eq!(
+            format!("{}", TinyInstructions::Dprint(TinyInput::Register(0))),
+            "0x21 0x00"
+        );
     }
 }

--- a/intermediate/132/rust/src/main.rs
+++ b/intermediate/132/rust/src/main.rs
@@ -48,6 +48,65 @@ enum TinyInstructions {
     Dprint(TinyInput) = 0x21,
 }
 
+impl TinyInstructions {
+    fn new(input: &str) -> Self {
+        let binding = input.to_lowercase();
+        let mut split = binding.split_whitespace();
+        match split.next().unwrap() {
+            "and" => Self::And(
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+            ),
+            "or" => Self::Or(
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+            ),
+            "xor" => Self::Xor(
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+            ),
+            "not" => Self::Not(TinyInput::new(split.next().unwrap())),
+            "mov" => Self::Mov(
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+            ),
+            "random" => Self::Random(TinyInput::new(split.next().unwrap())),
+            "add" => Self::Add(
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+            ),
+            "sub" => Self::Sub(
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+            ),
+            "jump" => Self::Jump(TinyInput::new(split.next().unwrap())),
+            "jz" => Self::Jz(
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+            ),
+            "jeq" => Self::Jeq(
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+            ),
+            "jls" => Self::Jls(
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+            ),
+            "jgt" => Self::Jgt(
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+                TinyInput::new(split.next().unwrap()),
+            ),
+            "halt" => Self::Halt,
+            "aprint" => Self::Aprint,
+            "dprint" => Self::Dprint(TinyInput::new(split.next().unwrap())),
+            _ => panic!("Invalid instruction"),
+        }
+    }
+}
+
 #[cfg(not(tarpaulin_include))]
 fn main() {
     println!("rad");
@@ -80,5 +139,85 @@ mod tests {
         assert_eq!(TinyInput::Value(5), TinyInput::new("5"));
         assert_eq!(TinyInput::Value(6), TinyInput::new("6"));
         assert_eq!(TinyInput::Value(70), TinyInput::new("70"));
+    }
+
+    #[test]
+    fn tinyinstructions_parses_all_instructions() {
+        assert_eq!(
+            TinyInstructions::And(TinyInput::Register(0), TinyInput::Value(1)),
+            TinyInstructions::new("and [0] 1")
+        );
+        assert_eq!(
+            TinyInstructions::Or(TinyInput::Register(0), TinyInput::Value(1)),
+            TinyInstructions::new("or [0] 1")
+        );
+        assert_eq!(
+            TinyInstructions::Xor(TinyInput::Register(0), TinyInput::Value(1)),
+            TinyInstructions::new("xor [0] 1")
+        );
+        assert_eq!(
+            TinyInstructions::Not(TinyInput::Register(0)),
+            TinyInstructions::new("not [0]")
+        );
+        assert_eq!(
+            TinyInstructions::Mov(TinyInput::Register(0), TinyInput::Value(1)),
+            TinyInstructions::new("mov [0] 1")
+        );
+        assert_eq!(
+            TinyInstructions::Random(TinyInput::Register(0)),
+            TinyInstructions::new("random [0]")
+        );
+        assert_eq!(
+            TinyInstructions::Add(TinyInput::Register(0), TinyInput::Value(1)),
+            TinyInstructions::new("add [0] 1")
+        );
+        assert_eq!(
+            TinyInstructions::Sub(TinyInput::Register(0), TinyInput::Value(1)),
+            TinyInstructions::new("sub [0] 1")
+        );
+        assert_eq!(
+            TinyInstructions::Jump(TinyInput::Register(0)),
+            TinyInstructions::new("jump [0]")
+        );
+        assert_eq!(
+            TinyInstructions::Jz(TinyInput::Register(0), TinyInput::Value(1)),
+            TinyInstructions::new("jz [0] 1")
+        );
+        assert_eq!(
+            TinyInstructions::Jeq(
+                TinyInput::Register(0),
+                TinyInput::Value(1),
+                TinyInput::Value(2)
+            ),
+            TinyInstructions::new("jeq [0] 1 2")
+        );
+        assert_eq!(
+            TinyInstructions::Jls(
+                TinyInput::Register(0),
+                TinyInput::Value(1),
+                TinyInput::Value(2)
+            ),
+            TinyInstructions::new("jls [0] 1 2")
+        );
+        assert_eq!(
+            TinyInstructions::Jgt(
+                TinyInput::Register(0),
+                TinyInput::Value(1),
+                TinyInput::Value(2)
+            ),
+            TinyInstructions::new("jgt [0] 1 2")
+        );
+        assert_eq!(TinyInstructions::Halt, TinyInstructions::new("halt"));
+        assert_eq!(TinyInstructions::Aprint, TinyInstructions::new("aprint"));
+        assert_eq!(
+            TinyInstructions::Dprint(TinyInput::Register(0)),
+            TinyInstructions::new("dprint [0]")
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn tinyinstructions_errors_with_unknown_instruction() {
+        TinyInstructions::new("unknown");
     }
 }

--- a/intermediate/132/rust/src/main.rs
+++ b/intermediate/132/rust/src/main.rs
@@ -18,6 +18,15 @@ enum TinyInput {
     Value(u8),
 }
 
+impl TinyInput {
+    fn new(input: &str) -> Self {
+        match input.chars().next().unwrap() {
+            '[' => Self::Register(input[1..input.len() - 1].parse::<u8>().unwrap()),
+            _ => Self::Value(input.parse::<u8>().unwrap()),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 #[repr(u8)]
 enum TinyInstructions {
@@ -50,7 +59,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_stub() {
-        assert_eq!(2 + 2, 4);
+    fn tinyinput_creates_registers() {
+        assert_eq!(TinyInput::Register(0), TinyInput::new("[0]"));
+        assert_eq!(TinyInput::Register(1), TinyInput::new("[1]"));
+        assert_eq!(TinyInput::Register(2), TinyInput::new("[2]"));
+        assert_eq!(TinyInput::Register(3), TinyInput::new("[3]"));
+        assert_eq!(TinyInput::Register(4), TinyInput::new("[4]"));
+        assert_eq!(TinyInput::Register(5), TinyInput::new("[5]"));
+        assert_eq!(TinyInput::Register(6), TinyInput::new("[6]"));
+        assert_eq!(TinyInput::Register(70), TinyInput::new("[70]"));
+    }
+
+    #[test]
+    fn tinyinput_creates_values() {
+        assert_eq!(TinyInput::Value(0), TinyInput::new("0"));
+        assert_eq!(TinyInput::Value(1), TinyInput::new("1"));
+        assert_eq!(TinyInput::Value(2), TinyInput::new("2"));
+        assert_eq!(TinyInput::Value(3), TinyInput::new("3"));
+        assert_eq!(TinyInput::Value(4), TinyInput::new("4"));
+        assert_eq!(TinyInput::Value(5), TinyInput::new("5"));
+        assert_eq!(TinyInput::Value(6), TinyInput::new("6"));
+        assert_eq!(TinyInput::Value(70), TinyInput::new("70"));
     }
 }

--- a/intermediate/132/rust/src/main.rs
+++ b/intermediate/132/rust/src/main.rs
@@ -1,0 +1,29 @@
+// Copyright 2023 CJ Harries
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(not(tarpaulin_include))]
+fn main() {
+    println!("rad");
+}
+
+#[cfg(not(tarpaulin_include))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stub() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/intermediate/132/rust/src/main.rs
+++ b/intermediate/132/rust/src/main.rs
@@ -13,6 +13,12 @@
 // limitations under the License.
 
 #[derive(Debug, PartialEq)]
+enum TinyInput {
+    Register(u8),
+    Value(u8),
+}
+
+#[derive(Debug, PartialEq)]
 enum TinyInstructions {
     And = 0x00,
     Or = 0x02,

--- a/intermediate/132/rust/src/main.rs
+++ b/intermediate/132/rust/src/main.rs
@@ -14,22 +14,22 @@
 
 #[derive(Debug, PartialEq)]
 enum TinyInstructions {
-    And,
-    Or,
-    Xor,
-    Not,
-    Mov,
-    Random,
-    Add,
-    Sub,
-    Jump,
-    Jz,
-    Jeq,
-    Jls,
-    Jgt,
-    Halt,
-    Aprint,
-    Dprint,
+    And = 0x00,
+    Or = 0x02,
+    Xor = 0x04,
+    Not = 0x06,
+    Mov = 0x07,
+    Random = 0x09,
+    Add = 0x0a,
+    Sub = 0x0c,
+    Jump = 0x0e,
+    Jz = 0x10,
+    Jeq = 0x14,
+    Jls = 0x18,
+    Jgt = 0x1c,
+    Halt = 0xff,
+    Aprint = 0x20,
+    Dprint = 0x21,
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/intermediate/132/rust/src/main.rs
+++ b/intermediate/132/rust/src/main.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #[derive(Debug, PartialEq)]
+#[repr(u8)]
 enum TinyInput {
     Register(u8),
     Value(u8),
@@ -23,6 +24,15 @@ impl TinyInput {
         match input.chars().next().unwrap() {
             '[' => Self::Register(input[1..input.len() - 1].parse::<u8>().unwrap()),
             _ => Self::Value(input.parse::<u8>().unwrap()),
+        }
+    }
+}
+
+impl std::fmt::Display for TinyInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Register(value) => write!(f, "{:#04x}", value),
+            Self::Value(value) => write!(f, "{:#04x}", value),
         }
     }
 }
@@ -139,6 +149,12 @@ mod tests {
         assert_eq!(TinyInput::Value(5), TinyInput::new("5"));
         assert_eq!(TinyInput::Value(6), TinyInput::new("6"));
         assert_eq!(TinyInput::Value(70), TinyInput::new("70"));
+    }
+
+    #[test]
+    fn tinyinput_prints_as_hex() {
+        assert_eq!(format!("{}", TinyInput::Register(0)), "0x00");
+        assert_eq!(format!("{}", TinyInput::Value(0)), "0x00");
     }
 
     #[test]


### PR DESCRIPTION
- Define intermediate #132
- Add boilerplate
- Create empty Rust file
- Define Rust package
- Create instruction enums
- Add memory values for instructions
- Add input struct
- Add instruction inputs
- Create and test TinyInput::new
- Create and test TinyInstructions::new
- Add printing for TinyInput
- Create and test TinyInstructions display
- Add exercise note
